### PR TITLE
quick fix for dealing .ng-hide's default styles

### DIFF
--- a/animate.js
+++ b/animate.js
@@ -15,6 +15,12 @@ angular.module('ngAnimate-animate.css', ['ngAnimate'])
         };
       }
       var animateCSSStart = function(element, className, delay, done) {
+        if(element.hasClass('ng-hide') && className.match(/Out/) ) {
+          element.attr('style', 'display: block !important');
+          $timeout(function() {
+            element.removeAttr('style');
+          }, delay || 2000, false);
+        }
         element.addClass(className);
         element.addClass('animated');
         $timeout(done, delay || 2000, false);


### PR DESCRIPTION
Since .ng-hide has a default `display: none !important` style, here's a quick fix for overriding the style until the animation is done.  For now it defaults to `display: block`, though so it may mess with elements styled differently.
