### PR TITLE
added .fade-in for compatibility with Bootstrap

### DIFF
--- a/animate.js
+++ b/animate.js
@@ -89,6 +89,10 @@ angular.module('ngAnimate-animate.css', ['ngAnimate'])
     return animateCSSBuild('fade','fadeIn','fadeOut');
   }])
 
+  .animation('.fade-in', ['animateCSSBuild', function(animateCSSBuild) {
+    return animateCSSBuild('fade','fadeIn','fadeOut');
+  }])
+
   .animation('.fade-up', ['animateCSSBuild', function(animateCSSBuild) {
     return animateCSSBuild('fade-up','fadeInUp','fadeOutUp');
   }])


### PR DESCRIPTION
Not sure if that's the best way to enable .fade with bootstrap, here's the name collision:

in bootstrap/less/component-animations.less:
.fade {
  opacity: 0;
  .transition(opacity .15s linear);
  &.in {
    opacity: 1;
  }
}
